### PR TITLE
Fix streaming on tomcat-7.0.27 + version.

### DIFF
--- a/modules/core/src/flex/messaging/endpoints/BaseStreamingHTTPEndpoint.java
+++ b/modules/core/src/flex/messaging/endpoints/BaseStreamingHTTPEndpoint.java
@@ -777,7 +777,6 @@ public abstract class BaseStreamingHTTPEndpoint extends BaseHTTPEndpoint
                 if (addNoCacheHeaders)
                     addNoCacheHeaders(req, res);
                 res.setContentType(getResponseContentType());
-                res.setHeader("Connection", "close");
                 res.setHeader("Transfer-Encoding", "chunked");
                 ServletOutputStream os = res.getOutputStream();
                 res.flushBuffer();


### PR DESCRIPTION
https://bz.apache.org/bugzilla/show_bug.cgi?id=53169

Tomcat close off the connection on connection-close header + chunk-encoding scenarios. Chunking happening only when there is no Connection: close header found. 
