### PR TITLE
Change method name from "rememberObject" to "putObject"

### DIFF
--- a/core/src/main/java/flex/messaging/util/ToStringPrettyPrinter.java
+++ b/core/src/main/java/flex/messaging/util/ToStringPrettyPrinter.java
@@ -220,12 +220,12 @@ public class ToStringPrettyPrinter extends BasicPrettyPrinter
         }
         else
         {
-            rememberObject(o);
+            putObject(o);
         }
         return (ref != null);
     }
     
-    private void rememberObject(Object o)
+    private void putObject(Object o)
     {
         knownObjects.put(o, new Integer(knownObjectsCount++));
     }


### PR DESCRIPTION
There is an explicit verb in the implementation of this method, *put*.
Hence, changing the method name to "putObject" can better describe the intention of this method.